### PR TITLE
fix(ci): pass delete-tags input to ghcr-cleanup-action

### DIFF
--- a/.github/workflows/shared-ghcr-cleanup.yaml
+++ b/.github/workflows/shared-ghcr-cleanup.yaml
@@ -119,6 +119,7 @@ jobs:
             repository: ${{ inputs.repository }}
             package: ${{ inputs.package }}
             expand-packages: ${{ inputs.expand-packages }}
+            delete-tags: ${{ inputs.delete-tags }}
             exclude-tags: ${{ inputs.exclude-tags }}
             delete-untagged: ${{ inputs.delete-untagged }}
             delete-ghost-images: ${{ inputs.delete-ghost-images }}


### PR DESCRIPTION
# Summary

Fixes a bug where the `delete-tags` input parameter was defined but not passed to the underlying `dataaxiom/ghcr-cleanup-action`, preventing callers from deleting specific tags using wildcard patterns.

# Changes Made

- Added `delete-tags: ${{ inputs.delete-tags }}` to the action's `with` section in `.github/workflows/shared-ghcr-cleanup.yaml`

# Related Issues

This enables PR-specific cleanup scenarios where workflows need to delete images matching patterns like `pr-{number}-*` when a PR is closed.