### PR TITLE
feat(e2e): add optional ref input to e2e action

### DIFF
--- a/workflows/e2e/action.yaml
+++ b/workflows/e2e/action.yaml
@@ -26,6 +26,10 @@ inputs:
   scenario:
     description: "The E2E scenario to run"
     required: true
+  ref:
+    description: "The ref to checkout (commit SHA, branch, or tag). Defaults to the repository default branch."
+    required: false
+    default: ""
 outputs:
   result:
     description: "The path to the E2E test results"
@@ -39,6 +43,7 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         repository: cloudoperators/greenhouse
+        ref: ${{ inputs.ref }}
 
     - name: Set up Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5


### PR DESCRIPTION
## Summary

- Adds an optional `ref` input to the `workflows/e2e` composite action
- When provided, the checkout step uses the given commit SHA, branch, or tag
- When omitted (default `""`), `actions/checkout` falls back to the default branch — preserving existing nightly behaviour

## Why

The `ci-e2e-run.yaml` workflow in `cloudoperators/greenhouse` is triggered via `issue_comment`, which always runs from the default branch. Without a `ref` input, the e2e action always checks out main instead of the PR's code.

## Test plan

- [ ] Nightly e2e (no `ref` passed) still checks out main
- [ ] Comment-driven e2e (PR SHA passed as `ref`) checks out the PR's commit