### PR TITLE
fix(actions): replace heredoc with env var to fix YAML parsing error

### DIFF
--- a/workflows/issue-triage/action.yaml
+++ b/workflows/issue-triage/action.yaml
@@ -23,18 +23,16 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
         ISSUE_URL: ${{ github.event.issue.html_url }}
+        COMMENT_BODY: |
+          Thanks for opening this issue! 🎉
+
+          A maintainer will triage it within 5 business days. You can learn more about our issue workflow in the [Issue Lifecycle documentation](https://github.com/cloudoperators/common/blob/main/ISSUE_LIFECYCLE.md).
+
+          In the meantime, please make sure you have provided:
+          - A clear problem statement
+          - Steps to reproduce (for bugs)
+          - Expected vs actual behavior
+
+          This helps us route your issue faster.
       run: |
-        BODY=$(cat <<'EOF'
-Thanks for opening this issue! 🎉
-
-A maintainer will triage it within 5 business days. You can learn more about our issue workflow in the [Issue Lifecycle documentation](https://github.com/cloudoperators/common/blob/main/ISSUE_LIFECYCLE.md).
-
-In the meantime, please make sure you have provided:
-- A clear problem statement
-- Steps to reproduce (for bugs)
-- Expected vs actual behavior
-
-This helps us route your issue faster.
-EOF
-        )
-        gh issue comment "$ISSUE_URL" --body "$BODY"
+        gh issue comment "$ISSUE_URL" --body "$COMMENT_BODY"


### PR DESCRIPTION
## Problem

The issue-triage workflow is failing across all repositories with:

```
cloudoperators/common/main/workflows/issue-triage/action.yaml: (Line: 30, Col: 1, Idx: 799) - While scanning a simple key, could not find expected ':'.
```

## Root Cause

The heredoc syntax (`cat <<'EOF'`) in the composite action's `run:` block causes the GitHub Actions manifest parser to fail. The unindented `EOF` delimiter at column 1 is interpreted as a YAML key by the parser.

## Fix

Replace the heredoc with a `COMMENT_BODY` environment variable using YAML block scalar (`|`). This is properly parsed by both the YAML parser and the GitHub Actions manifest loader, and avoids Markdown indentation issues in the rendered comment.