### PR TITLE
fix(actions): avoid empty lines in block scalar to fix legacy YAML parser

### DIFF
--- a/workflows/issue-triage/action.yaml
+++ b/workflows/issue-triage/action.yaml
@@ -23,16 +23,5 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
         ISSUE_URL: ${{ github.event.issue.html_url }}
-        COMMENT_BODY: |
-          Thanks for opening this issue! 🎉
-
-          A maintainer will triage it within 5 business days. You can learn more about our issue workflow in the [Issue Lifecycle documentation](https://github.com/cloudoperators/common/blob/main/ISSUE_LIFECYCLE.md).
-
-          In the meantime, please make sure you have provided:
-          - A clear problem statement
-          - Steps to reproduce (for bugs)
-          - Expected vs actual behavior
-
-          This helps us route your issue faster.
       run: |
-        gh issue comment "$ISSUE_URL" --body "$COMMENT_BODY"
+        gh issue comment "$ISSUE_URL" --body "$(printf 'Thanks for opening this issue! 🎉\n\nA maintainer will triage it within 5 business days. See the [Issue Lifecycle documentation](https://github.com/cloudoperators/common/blob/main/ISSUE_LIFECYCLE.md) for details.\n\nIn the meantime, please make sure you have provided:\n- A clear problem statement\n- Steps to reproduce (for bugs)\n- Expected vs actual behavior')"

--- a/workflows/issue-triage/action.yaml
+++ b/workflows/issue-triage/action.yaml
@@ -24,4 +24,4 @@ runs:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
         ISSUE_URL: ${{ github.event.issue.html_url }}
       run: |
-        gh issue comment "$ISSUE_URL" --body "$(printf 'Thanks for opening this issue! 🎉\n\nA maintainer will triage it within 5 business days. See the [Issue Lifecycle documentation](https://github.com/cloudoperators/common/blob/main/ISSUE_LIFECYCLE.md) for details.\n\nIn the meantime, please make sure you have provided:\n- A clear problem statement\n- Steps to reproduce (for bugs)\n- Expected vs actual behavior')"
+        gh issue comment "$ISSUE_URL" --body "$(printf '%b' 'Thanks for opening this issue! 🎉\n\nA maintainer will triage it within 5 business days. See the [Issue Lifecycle documentation](https://github.com/cloudoperators/common/blob/main/ISSUE_LIFECYCLE.md) for details.\n\nIn the meantime, please make sure you have provided:\n- A clear problem statement\n- Steps to reproduce (for bugs)\n- Expected vs actual behavior\n\nThis helps us route your issue faster.')"


### PR DESCRIPTION
## Problem

The Issue Triage workflow is still failing even after PR #61, with the same error:

```
cloudoperators/common/main/workflows/issue-triage/action.yaml: (Line: 30, Col: 1, Idx: 799) - While scanning a simple key, could not find expected ':'.
```

## Root Cause

The fix in #61 replaced the heredoc with a `COMMENT_BODY` env variable using a YAML literal block scalar (`|`). However, the block scalar contained **empty lines** (lines with no characters at all) for paragraph breaks in the comment body.

The GitHub Actions **legacy manifest parser** (`ActionManifestManagerLegacy`) does not handle bare empty lines inside block scalar values correctly — it interprets them as potential YAML keys rather than block scalar continuations, causing the 'could not find expected :' error.

## Fix

Replace the multi-line block scalar env var approach with a single `printf` call inside the `run:` step. This keeps all content on a single YAML line with `\n` escape sequences for newlines, and avoids any empty lines in the YAML structure entirely.

## Supersedes

This supersedes PR #61.